### PR TITLE
Update description in appdata

### DIFF
--- a/net.redeclipse.RedEclipse.appdata.xml
+++ b/net.redeclipse.RedEclipse.appdata.xml
@@ -12,7 +12,7 @@
   <description>
     <p>
       Red Eclipse is a fun-filled new take on the first person arena shooter,
-      built as a total conversion of Cube Engine 2, which lends itself toward
+      based on the Tesseract game engine, which lends itself toward
       a balanced gameplay, with a general theme of agility in a variety of
       environments.
     </p>


### PR DESCRIPTION
Red Eclipse versions 2.0.0 and higher are based on the Tesseract engine, not Cube 2.

On another note, I also think the screenshots need to be updated, because the current ones are from versions 1.x.x. However, I'm not sure if it's worth doing it now, or after the release of 2.1.0, because 2.1.0 also looks somewhat different to 2.0.0.