### PR TITLE
Add x-checker-data to redeclipse and update screenshots

### DIFF
--- a/net.redeclipse.RedEclipse.appdata.xml
+++ b/net.redeclipse.RedEclipse.appdata.xml
@@ -23,10 +23,10 @@
       <li>Builtin editor lets you create your own maps cooperatively online</li>
     </ul>
   </description>
-  <url type="homepage">https://redeclipse.net/</url>
+  <url type="homepage">https://www.redeclipse.net/</url>
   <url type="bugtracker">https://github.com/redeclipse/base/issues</url>
-  <url type="donation">https://redeclipse.net/donate</url>
-  <url type="help">https://redeclipse.net/faq</url>
+  <url type="donation">https://www.redeclipse.net/donate</url>
+  <url type="help">https://www.redeclipse.net/faq</url>
   <screenshots>
     <screenshot type="default">
       <image>https://shared.fastly.steamstatic.com/store_item_assets/steam/apps/967460/ss_14873d8586cea19cc43e8e4a90f176929fe0b1d7.1920x1080.jpg</image>

--- a/net.redeclipse.RedEclipse.appdata.xml
+++ b/net.redeclipse.RedEclipse.appdata.xml
@@ -29,16 +29,16 @@
   <url type="help">https://redeclipse.net/faq</url>
   <screenshots>
     <screenshot type="default">
-      <image>https://redeclipse.net/bits/images/053.jpg</image>
-      <caption>Posing with fire on the map venus</caption>
+      <image>https://shared.fastly.steamstatic.com/store_item_assets/steam/apps/967460/ss_14873d8586cea19cc43e8e4a90f176929fe0b1d7.1920x1080.jpg</image>
+      <caption>Sniping on the map Fortitude</caption>
     </screenshot>
     <screenshot>
-      <image>https://redeclipse.net/bits/images/045.jpg</image>
-      <caption>Mine fireworks on the map vault</caption>
+      <image>https://shared.fastly.steamstatic.com/store_item_assets/steam/apps/967460/ss_790730ce35cdace359cb1464dcdd350c96ff8d96.1920x1080.jpg</image>
+      <caption>Awaiting the enemy on the map Rift</caption>
     </screenshot>
     <screenshot>
-      <image>https://redeclipse.net/bits/images/019.jpg</image>
-      <caption>Overlooking friendly fire on the map cutec</caption>
+      <image>https://shared.fastly.steamstatic.com/store_item_assets/steam/apps/967460/ss_2e9171a35e307846aef3956c1e33e11144f65aec.1920x1080.jpg</image>
+      <caption>Race map Cyanide</caption>
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1">

--- a/net.redeclipse.RedEclipse.yml
+++ b/net.redeclipse.RedEclipse.yml
@@ -29,6 +29,7 @@ modules:
           project-id: 8261
           stable-only: true
           url-template: https://github.com/redeclipse/base/releases/download/v$version/redeclipse_$version_nix.tar.bz2
+          is-main-source: true
       - type: file
         url: https://raw.githubusercontent.com/redeclipse/base/master/src/install/nix/redeclipse.desktop.am
         sha256: 8060b6cfb23ebb191da0b3aa8267b156f0a3812ed7fea9266efecacbc9c962fe

--- a/net.redeclipse.RedEclipse.yml
+++ b/net.redeclipse.RedEclipse.yml
@@ -24,6 +24,11 @@ modules:
       - type: archive
         url: https://github.com/redeclipse/base/releases/download/v2.0.0/redeclipse_2.0.0_nix.tar.bz2
         sha256: b15c14214e4b86c232828b39d3531fa9217b41bc695892f10166aef746387190
+        x-checker-data:
+          type: anitya
+          project-id: 8261
+          stable-only: true
+          url-template: https://github.com/redeclipse/base/releases/download/v$version/redeclipse_$version_nix.tar.bz2
       - type: file
         url: https://raw.githubusercontent.com/redeclipse/base/master/src/install/nix/redeclipse.desktop.am
         sha256: 8060b6cfb23ebb191da0b3aa8267b156f0a3812ed7fea9266efecacbc9c962fe


### PR DESCRIPTION
In my previous PR I forgot to add x-checker-data to redeclipse. This should add everything automatically when a new version comes out, including the new version number to metadata.