### PR TITLE
Use .desktop file from src dir instead of downloading it separately

### DIFF
--- a/net.redeclipse.RedEclipse.yml
+++ b/net.redeclipse.RedEclipse.yml
@@ -31,10 +31,6 @@ modules:
           url-template: https://github.com/redeclipse/base/releases/download/v$version/redeclipse_$version_nix.tar.bz2
           is-main-source: true
       - type: file
-        url: https://raw.githubusercontent.com/redeclipse/base/master/src/install/nix/redeclipse.desktop.am
-        sha256: 8060b6cfb23ebb191da0b3aa8267b156f0a3812ed7fea9266efecacbc9c962fe
-        dest-filename: redeclipse.desktop
-      - type: file
         path: net.redeclipse.RedEclipse.appdata.xml
       - type: file
         path: redeclipse.sh
@@ -46,6 +42,6 @@ modules:
       - cp -r ../config /app/share/redeclipse/
       - cp -r ../data /app/share/redeclipse/
       - install -Dm644 ../net.redeclipse.RedEclipse.appdata.xml /app/share/appdata/net.redeclipse.RedEclipse.appdata.xml
-      - install -Dm644 ../redeclipse.desktop /app/share/applications/net.redeclipse.RedEclipse.desktop
+      - install -Dm644 ../src/install/nix/redeclipse.desktop.am /app/share/applications/net.redeclipse.RedEclipse.desktop
       - install -Dm644 ../src/install/nix/redeclipse_x128.png /app/share/icons/hicolor/128x128/apps/net.redeclipse.RedEclipse.png
       - desktop-file-edit --set-icon=net.redeclipse.RedEclipse --set-key=Exec --set-value=redeclipse /app/share/applications/net.redeclipse.RedEclipse.desktop


### PR DESCRIPTION
For current RE versions there probably isn't much sense to download the latest master .desktop file separately, since it doesn't get changed that often anyway (see [its commit history](https://github.com/redeclipse/base/commits/master/src/install/nix/redeclipse.desktop.am)) and when it does, you'll not have to re-check its sha256 every time.

Today it was updated to remove PreferNonDefaultGPU because there's a wide consensus that it's broken, so now the latest master .desktop file is identical to the one that's in current version 2.0.0.

The only thing I'm not so sure about is whether the -Dm644 command can properly rename the file extension from .desktop.am to .desktop. But the build currently seems to be succeeding.