### PR TITLE
Use upstream specified compile flags and switch to default buildsystem

### DIFF
--- a/net.redeclipse.RedEclipse.yml
+++ b/net.redeclipse.RedEclipse.yml
@@ -14,11 +14,16 @@ finish-args:
 modules:
 
   - name: redeclipse
-    buildsystem: cmake-ninja
+    no-autogen: true
+    no-make-install: true
+    build-options:
+      cflags: -O3 -fomit-frame-pointer
+      cflags-override: true
+      cxxflags: -O3 -fomit-frame-pointer -ffast-math -fno-finite-math-only
+      cxxflags-override: true
     config-opts:
       - -DWANT_DISCORD=0
       - -DWANT_STEAM=0
-    no-make-install: true
     subdir: src
     sources:
       - type: archive


### PR DESCRIPTION
I've noticed that Flathub's buildsystems ignore the primary compile flags that are specified in the upstream makefile (-O3, -fomit-frame-pointer, etc) and completely replace them with FD SDK's default flags, including those that potentially hurt performance like -fno-omit-frame-pointer. This change makes sure that only the upstream specified flags are used.
The cxxflags are set accordingly to the [game's makefile](https://github.com/redeclipse/base/blob/master/src/Makefile), while the cflags are set accordingly to the [bundled enet library makefile](https://github.com/redeclipse/base/blob/master/src/enet/Makefile).
After I made this change to net.redeclipse.RedEclipse-Legacy, I've noticed lower CPU usage and faster loading times.

Regarding the buildsystem switch, I think it's better to use the default buildsystem unless there are clear advantages in using cmake-ninja.
While maintaining net.redeclipse.RedEclipse-Legacy, cmake-ninja has caused some issues for me, like not applying a patch properly. The default buildsystem also outputs better logs imo.