### PR TITLE
Install .sh files for all binaries into bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+## Running additional binaries
+
+Apart from the game itself, additional Red Eclipse binaries can be launched via the following commands:
+
+Server: `flatpak run --command=redeclipse_server net.redeclipse.RedEclipse`
+
+Genkey: `flatpak run --command=genkey net.redeclipse.RedEclipse`

--- a/genkey.sh
+++ b/genkey.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd "/app/share/redeclipse" || exit 1
+exec "./genkey" "$@"

--- a/net.redeclipse.RedEclipse.yml
+++ b/net.redeclipse.RedEclipse.yml
@@ -39,8 +39,14 @@ modules:
         path: net.redeclipse.RedEclipse.appdata.xml
       - type: file
         path: redeclipse.sh
+      - type: file
+        path: redeclipse_server.sh
+      - type: file
+        path: genkey.sh
     post-install:
       - install -Dm755 ../redeclipse.sh /app/bin/redeclipse
+      - install -Dm755 ../redeclipse_server.sh /app/bin/redeclipse_server
+      - install -Dm755 ../genkey.sh /app/bin/genkey
       - install -Dm755 redeclipse_linux /app/share/redeclipse/redeclipse
       - install -Dm755 redeclipse_server_linux /app/share/redeclipse/redeclipse_server
       - install -Dm755 genkey_linux /app/share/redeclipse/genkey

--- a/redeclipse_server.sh
+++ b/redeclipse_server.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd "/app/share/redeclipse" || exit 1
+exec "./redeclipse_server" "$@"


### PR DESCRIPTION
In one of the previous PRs we decided to keep all RE binaries. But only the main game binary has its appropriate .sh file installed into bin, so currently the only way to launch the other binaries is via typing the full path to them (is that even possible?)

I made the .sh files based on redeclipse.sh for the other binaries, so now it'll be possible to launch them via a single command.

I've also added a readme with instructions for launching the other binaries in a similar fashion to [Xonotic Flatpak](https://github.com/flathub/org.xonotic.Xonotic/blob/master/README.md).