### PR TITLE
Use SDL2_image shared module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/net.redeclipse.RedEclipse.yml
+++ b/net.redeclipse.RedEclipse.yml
@@ -15,11 +15,14 @@ cleanup:
   - /include
   - /lib/cmake
   - /lib/pkgconfig
-  - '*.la'
-  - '*.a'
 modules:
 
   - name: sdl2_image
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DSDL2IMAGE_DEPS_SHARED=OFF
+      - -DSDL2IMAGE_STRICT=ON
     sources:
       - type: archive
         url: https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.8/SDL2_image-2.8.8.tar.gz

--- a/net.redeclipse.RedEclipse.yml
+++ b/net.redeclipse.RedEclipse.yml
@@ -11,27 +11,9 @@ finish-args:
   - --socket=wayland
   - --socket=pulseaudio
   - --persist=.redeclipse
-cleanup:
-  - /include
-  - /lib/cmake
-  - /lib/pkgconfig
 modules:
 
-  - name: sdl2_image
-    buildsystem: cmake-ninja
-    builddir: true
-    config-opts:
-      - -DSDL2IMAGE_DEPS_SHARED=OFF
-      - -DSDL2IMAGE_STRICT=ON
-    sources:
-      - type: archive
-        url: https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.8/SDL2_image-2.8.8.tar.gz
-        sha256: 2213b56fdaff2220d0e38c8e420cbe1a83c87374190cba8c70af2156097ce30a
-        x-checker-data:
-          type: anitya
-          project-id: 382729
-          stable-only: true
-          url-template: https://github.com/libsdl-org/SDL_image/releases/download/release-$version/SDL2_image-$version.tar.gz
+  - shared-modules/SDL2/SDL2_image.json
 
   - name: redeclipse
     no-autogen: true

--- a/net.redeclipse.RedEclipse.yml
+++ b/net.redeclipse.RedEclipse.yml
@@ -12,7 +12,6 @@ finish-args:
   - --socket=pulseaudio
   - --persist=.redeclipse
 modules:
-
   - shared-modules/SDL2/SDL2_image.json
 
   - name: redeclipse


### PR DESCRIPTION
Just noticed that SDL2_image shared module has already been [merged](https://github.com/flathub/shared-modules/blob/master/SDL2/SDL2_image.json), so it's better to use that.
Already tested this with Red Eclipse Legacy and it works fine.